### PR TITLE
Add support for win32 vimhome

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -14,7 +14,12 @@ if has('nvim')
   set shada='100,<1000,s1000,:1000
   set clipboard=unnamedplus
 else
-  let g:vimhome = SafeDirectory('~/.vim')
+  if has('win32')
+    let g:vimhome = SafeDirectory('~/vimfiles')
+  else
+    let g:vimhome = SafeDirectory('~/.vim')
+  endif
+  
   set clipboard+=autoselect
 endif
 


### PR DESCRIPTION
Windows uses ~/vimhome instead of ~/.vim  This is especially important for the autoload file setup even if you make a symlink ~/.vim ~/vimhome